### PR TITLE
iOS: enable Significant Location Change (SLC)

### DIFF
--- a/src/plugins/position/corelocation/qgeopositioninfosource_cl.mm
+++ b/src/plugins/position/corelocation/qgeopositioninfosource_cl.mm
@@ -176,6 +176,10 @@ bool QGeoPositionInfoSourceCL::enableLocationManager()
 
 #if defined(Q_OS_IOS) || defined(Q_OS_WATCHOS)
         if (__builtin_available(watchOS 4.0, *)) {
+            // enable Significant-Change Location (Significant Location Change or SLC)
+            if (([CLLocationManager authorizationStatus]) == kCLAuthorizationStatusAuthorizedAlways)
+                [m_locationManager startMonitoringSignificantLocationChanges];
+
             NSDictionary<NSString *, id> *infoDict = [[NSBundle mainBundle] infoDictionary];
             if (id value = [infoDict objectForKey:@"UIBackgroundModes"]) {
                 if ([value isKindOfClass:[NSArray class]]) {


### PR DESCRIPTION
The significant-change location service offers a more power-friendly
alternative for apps that need location data but do not need frequent
updates or the precision of GPS. Delivers location updates to your app
only when the user’s position changes by a significant amount, such as
500 meters or more.

If app is subsequently suspended or terminated, the service
automatically wakes up your app when new location data arrives. At
wake-up time, the app is put into the background and you are given a
small amount of time (around 10 seconds) to manually restart location
services and process the location data.

Requires "always authorization", so we enable SLC only if user
granted "always" permission.

Doesn't require "UIBackgroundModes" (SLC is independent from background
mode).

Here is console log from iPhone 7 (iOS 12.0.1) when app waked up due SLC
update and then suspended after 10 seconds:

locationd {"msg":"#SLC Got location", "location":<private>}
locationd [FBSSystemService][0x94fa] Sending request to open "com.absmap.absmap"
...
assertiond [absmapclient] Setting up BG permission check timer for 10s
...
after 10 seconds
assertiond      [absmapclient] suspend success

Signed-off-by: Abylay Ospan <aospan@jokersys.com>